### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,11 +12,11 @@ TridentTD_7Segs74HC595	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-init               KEYWORD2
-setNumber 	       KEYWORD2
-setText            KEYWORD2
-setTextScroll      KEYWORD2
-getVersion         KEYWORD2
+init	KEYWORD2
+setNumber	KEYWORD2
+setText	KEYWORD2
+setTextScroll	KEYWORD2
+getVersion	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords